### PR TITLE
Upgrade AMP to Python 3.8

### DIFF
--- a/.project-metadata.yaml
+++ b/.project-metadata.yaml
@@ -2,19 +2,13 @@ name: NeuralQA
 description: Launches NeuralQA User Interface
 author: Cloudera Inc.
 specification_version: 1.0
-prototype_version: 1.0
-date: "2020-09-29"
-api_version: 1
+prototype_version: 2.0
+date: "2022-04-18"
 
 runtimes:
   - editor: Workbench
-    kernel: Python 3.6
+    kernel: Python 3.8
     edition: Standard
-
-engine_images:
-  - image_name: engine
-    tags:
-      - 14
 
 tasks:
   - type: create_job
@@ -27,7 +21,6 @@ tasks:
     short_summary: Job to install dependencies and download training data.
     environment:
       TASK_TYPE: CREATE/RUN_JOB
-    kernel: python3
 
   - type: run_job
     entity_label: install_deps
@@ -46,4 +39,3 @@ tasks:
     memory: 6
     environment_variables:
       TASK_TYPE: START_APPLICATION
-    kernel: python3

--- a/install_deps.py
+++ b/install_deps.py
@@ -39,4 +39,4 @@
 # ###########################################################################
 
 !pip3 install --upgrade pip
-!pip3 install -q -r requirements.txt
+!pip3 install -r requirements.txt


### PR DESCRIPTION
This resolves [DSE-20697](https://jira.cloudera.com/browse/DSE-20697)

Left dependencies pinned as they were and upgraded to most recent Python version possible. 

AMP completes setup and NeuralQA application runs on both PC and PvC. 