### PR TITLE
DSE-27001: Fix NeuralQA AMP

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+torch<2.0
 neuralqa==0.0.31a0
 transformers==3.0.2


### PR DESCRIPTION
This PR fixes the neuralQA AMP which has failed on prod due to a newer torch version that is not compatible with this AMP

